### PR TITLE
Improve gallery modal interactions

### DIFF
--- a/src/components/gallery/GalleryGrid.tsx
+++ b/src/components/gallery/GalleryGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Heart, Download, Share2, Eye, Tag } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Photo, mockPhotos } from '@/lib/mock-photo-data';
@@ -26,6 +26,27 @@ export function GalleryGrid({
 }: GalleryGridProps) {
   const [selectedPhoto, setSelectedPhoto] = useState<Photo | null>(null);
   const [likedPhotos, setLikedPhotos] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!selectedPhoto) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedPhoto(null);
+      }
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedPhoto]);
 
   // Filter photos based on selected tags and search query
   const filteredPhotos = mockPhotos.filter(photo => {
@@ -211,8 +232,14 @@ export function GalleryGrid({
 
       {/* Photo Detail Modal - Placeholder for future implementation */}
       {selectedPhoto && (
-        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-slate-800 rounded-xl max-w-4xl w-full max-h-[90vh] overflow-auto">
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+          onClick={() => setSelectedPhoto(null)}
+        >
+          <div
+            className="bg-white dark:bg-slate-800 rounded-xl max-w-4xl w-full max-h-[90vh] overflow-auto"
+            onClick={(event) => event.stopPropagation()}
+          >
             <div className="p-6">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-2xl font-bold">{selectedPhoto.title}</h2>


### PR DESCRIPTION
## Summary
Improves the GalleryGrid photo detail modal so it behaves like a standard dismissible overlay without changing its current UI or placeholder content.

## What changed
- close the modal when the user presses Escape
- close the modal when the backdrop is clicked
- disable page scrolling while the modal is open, then restore the previous body overflow state on close

## Notes
The interaction changes are isolated to `GalleryGrid.tsx` and preserve the existing modal layout and content.